### PR TITLE
Update core.selectbox.cshtml

### DIFF
--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.selectbox.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.selectbox.cshtml
@@ -1,7 +1,7 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.SelectBoxField>
 <div class="form-group @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
-  <select class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" ng-model="formData.@Model.FormSafeName" @(Model.MultiSelect ? "multiple" : "") size="@(Model.MultiSelect ? Model.FieldValues.Count()" @(Model.Mandatory ? "required" : null)>
+  <select class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" ng-model="formData.@Model.FormSafeName" @(Model.MultiSelect ? "multiple" : "") size="@(Model.MultiSelect ? Model.FieldValues.Count() : 0)" @(Model.Mandatory ? "required" : null)>
     @foreach (var fieldValue in Model.FieldValues)
     {
       <option value="@fieldValue.Value" @(fieldValue.Selected ? "selected" : "")>@fieldValue.Value</option>

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.selectbox.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.selectbox.cshtml
@@ -1,7 +1,7 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.SelectBoxField>
 <div class="form-group @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
-  <select class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" @(Model.MultiSelect ? "multiple" : "") size="@Model.FieldValues.Count()" @(Model.Mandatory ? "required" : null)>
+  <select class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" ng-model="formData.@Model.FormSafeName" @(Model.MultiSelect ? "multiple" : "") size="@(Model.MultiSelect ? Model.FieldValues.Count()" @(Model.Mandatory ? "required" : null)>
     @foreach (var fieldValue in Model.FieldValues)
     {
       <option value="@fieldValue.Value" @(fieldValue.Selected ? "selected" : "")>@fieldValue.Value</option>


### PR DESCRIPTION
size
If the control is presented as a scrolled list box, this attribute represents the number of rows in the list that should be visible at one time. Browsers are not required to present a select element as a scrolled list box. The default value is 0.
https://developer.mozilla.org/en/docs/Web/HTML/Element/select