### PR TITLE
Rendering overhaul

### DIFF
--- a/Docs/install.md
+++ b/Docs/install.md
@@ -25,7 +25,7 @@ In the "Row layouts" section of the configuration you'll set up the row layouts 
 
 Form Editor ships with a bunch of row icons, but if you run out of icons you can add more simply by dumping them in */App_Plugins/FormEditor/editor/rows/*.
 
-By default, Form Editor will suggest [Bootstrap](http://getbootstrap.com/css/#grid) style `.col-md-*` classes as cell aliases, mostly because the sample templates shipped with Form Editor use Bootstrap to render the form grid. But Form Editor is not tied to Bootstrap in any way. You have complete control over the [form rendering](render.md), so just use whatever cell alias that makes sense. 
+By default, Form Editor will suggest [Bootstrap](http://getbootstrap.com/css/#grid) style `.col-md-*` classes as cell aliases, mainly because the sample templates shipped with Form Editor use Bootstrap to render the form grid. But Form Editor is not tied to Bootstrap in any way. You have complete control over the [form rendering](render.md), so just use whatever cell alias that makes sense. 
 
 ##### Field type groups
 Form Editor ships with a bunch of field types (textbox, email, select box etc.). By default they are all listed in alphabetical order when the editors add a new field to a form. You can change this by grouping the available field types into field type groups, which is a great way to help your editors find the field types they need. 

--- a/Docs/install.md
+++ b/Docs/install.md
@@ -7,11 +7,11 @@ First and foremost grab the [latest Form Editor package](https://github.com/kjac
 Or, if you're using NuGet, you can install the [Form Editor](https://www.nuget.org/packages/FormEditor/) NuGet package. 
 
 ## Setting up the data types
-Once the package is installed, go ahead and create a "Form Editor" data type. 
+Once the package is installed, go ahead and create a Form Editor data type. 
 
 ![Form Editor data types](img/data types.png)
 
-### Configuring the data type "Form Editor"
+### Configuring the Form Editor data type
 
 ##### Row layouts
 In the "Row layouts" section of the configuration you'll set up the row layouts you want available for your editors. A row layout consists of:
@@ -38,14 +38,14 @@ Form Editor supports two different types of emails - notification emails (sent t
 You can choose separate email templates for notification and confirmation emails, or leave them blank if you don't want to support one or both types of emails. See [Email templates](emails.md) for more info.
 
 ##### The rest
-Hopefully the rest of the "Form Editor" data type configuration is self explanatory. Oh, and it's strongly recommended to hide the property label to give the "Form Editor" property as much space as possible.
+Hopefully the rest of the Form Editor data type configuration is self explanatory. Oh, and it's strongly recommended to hide the property label to give the Form Editor property as much space as possible.
 
 ## Setting up the content type
-When you have configured the data type, create a content type (or reuse an existing) and add a property based on the new "Form Editor" data type. If you're going to use the sample templates, make sure the "Form Editor" property has the property alias "form".
+When you have configured the data type, create a content type (or reuse an existing) and add a property based on the new Form Editor data type. If you're going to use the templates and views shipped with Form Editor for rendering (see [Rendering the form](render.md)), make sure the Form Editor property has the property alias "form".
 
-Since the "Form Editor" property takes up a lot of space in the UI, you should consider placing it on a separate tab - e.g. "Form".
+Since the Form Editor data type takes up a lot of space in the UI, you should consider placing the property on a separate tab - e.g. "Form".
 
-**Please note:** You can only have *one* "Form Editor" property per content type.
+**Please note:** You can only have *one* Form Editor property per content type.
 
 ## Next step
 Onwards to [Rendering the form](render.md).

--- a/Docs/render.md
+++ b/Docs/render.md
@@ -16,7 +16,7 @@ By completing these three steps, you'll have your first form rendered in no time
 
 Have a look at the sample templates to see actual implementations of this.
 
-**Note:** If you have named your Form Editor property something else than "form" (see [Installing and setting up Form Editor](install.md#setting-up-the-content-type)), you can specify the property name like this: ```ViewBag.FormName = "myForm";```
+**Note:** If you have named your Form Editor property something else than "form" (see [Installing and setting up Form Editor](install.md)), you can specify the property name like this: ```ViewBag.FormName = "myForm";```
 
 ## Creating your own rendering
 If you want to create your own renderings, the sample templates and partial views should always be your starting point for inspiration. They are fairly well documented and will not be discussed in detail here. However, a few things are worth mentioning.

--- a/Docs/render.md
+++ b/Docs/render.md
@@ -3,9 +3,25 @@ To make sure you hit the ground running, Form Editor ships with premade partial 
 
 The package also installs two sample templates that demonstrate how to use the partial views - one that demonstrates [synchronous form postback](../Source/Umbraco/Views/FormEditorSync.cshtml) and one that demonstrates [asynchronous form postback](../Source/Umbraco/Views/FormEditorAsync.cshtml).
 
-The sample templates and partial views are fairly well documented and will not be discussed in detail here. However, a few things are worth mentioning, in case you want feel like creating your own renderings.
+## 1-2-3-done!
+By completing these three steps, you'll have your first form rendered in no time:
 
-## Rendering rows, cells and fields
+1. Render the applicable partial view in your template: 
+    * Use ```@Html.Partial("FormEditor/Sync", Umbraco.AssignedContentItem);``` for synchronous form postback.
+    * Use  ```@Html.Partial("FormEditor/Async", Umbraco.AssignedContentItem);``` for asynchronous form postback.
+2. Make sure you have included either [jQuery](https://jquery.com/) or [AngularJS](https://angularjs.org/) in your template (even if you're using synchronous form postback, you'll still want scripting support for client side validation).
+3. Include the applicable Form Editor script for handling validation and form submission:
+    * Use ```/JS/FormEditor/FormEditorSync.js``` for synchronous form postback.
+    * Use ```/JS/FormEditor/FormEditorAsync.js``` for asynchronous form postback.
+
+Have a look at the sample templates to see actual implementations of this.
+
+**Note:** If you have named your Form Editor property something else than "form" (see [Installing and setting up Form Editor](install.md)), you can specify the property name like this: ```ViewBag.FormName = "myForm";```
+
+## Creating your own rendering
+If you want to create your own renderings, the sample templates and partial views should always be your starting point for inspiration. They are fairly well documented and will not be discussed in detail here. However, a few things are worth mentioning.
+
+### Rendering rows, cells and fields
 As mentioned in the [setup guide](install.md), the rows and cells have aliases to help you recognize them when rendering the form. 
 
 As for field rendering, Form Editor uses partial views to render all form fields. The partial views are referenced by convention based on the field `Type` name, and are expected to be located at:
@@ -45,7 +61,7 @@ The following code sample shows how this could all be pieced together:
 </div>
 ```
 
-## Submitting form data using synchronous postback
+### Submitting form data using synchronous postback
 When using synchronous postback for form submission, simply call `CollectSubmittedValues()` on the `FormModel` property and everything (including redirects to the success page, if configured) will be handled for you: 
 
 ```cs
@@ -55,7 +71,7 @@ var form = Model.Content.GetPropertyValue<FormModel>("form");
 form.CollectSubmittedValues();
 ```
 
-## Submitting form data using asynchronous postback
+### Submitting form data using asynchronous postback
 When using asynchronous postback for form submission you'll need to create a `FormData` object, populate it with the form data you want to submit and POST it to the Form Editor `SubmitEntry` endpoint at */umbraco/FormEditorApi/Public/SubmitEntry/* - like this: 
 
 ```javascript

--- a/Docs/render.md
+++ b/Docs/render.md
@@ -1,10 +1,14 @@
 # Rendering the form
-Form Editor ships with two sample templates, one that demonstrates [synchronous form postback](../Source/Umbraco/Views/FormEditorSync.cshtml) and one that demonstrates [asynchronous form postback](../Source/Umbraco/Views/FormEditorAsync.cshtml) (using [AngularJS](https://angularjs.org/)). Once the package is installed, these sample templates are located at */Views/FormEditorSync.cshtml* and */Views/FormEditorAsync.cshtml* respectively. They are fairly well documented and will not be discussed in detail here. However, a few things are worth mentioning.
+To make sure you hit the ground running, Form Editor ships with premade partial views for [synchronous form postback](../Source/Umbraco/Views/Partials/FormEditor/Sync.cshtml) (using [jQuery](https://jquery.com/)) and [asynchronous form postback](../Source/Umbraco/Views/Partials/FormEditor/Async.cshtml) (using [AngularJS](https://angularjs.org/)). Once the package is installed, these partial views can be found at */Views/Partials/FormEditor/*. 
+
+The package also installs two sample templates that demonstrate how to use the partial views - one that demonstrates [synchronous form postback](../Source/Umbraco/Views/FormEditorSync.cshtml) and one that demonstrates [asynchronous form postback](../Source/Umbraco/Views/FormEditorAsync.cshtml).
+
+The sample templates and partial views are fairly well documented and will not be discussed in detail here. However, a few things are worth mentioning, in case you want feel like creating your own renderings.
 
 ## Rendering rows, cells and fields
 As mentioned in the [setup guide](install.md), the rows and cells have aliases to help you recognize them when rendering the form. 
 
-As for field rendering, the sample templates use partial views to render all form fields. The partial views are referenced by convention based on the field `Type` name, and are expected to be located at:
+As for field rendering, Form Editor uses partial views to render all form fields. The partial views are referenced by convention based on the field `Type` name, and are expected to be located at:
 * */Views/Partials/FormEditor/FieldsSync/* for synchronous form postback 
 * */Views/Partials/FormEditor/FieldsAsync/* for asynchronous postback 
 
@@ -16,7 +20,6 @@ The following code sample shows how this could all be pieced together:
   var form = Model.Content.GetPropertyValue<FormModel>("form");
 }
 <div class="container">
-  @* NOTE: if you're not using form pages, you can access all form rows directly with form.Rows *@
   @foreach (var page in form.Pages)
   {
     <div class="form-page">
@@ -30,7 +33,7 @@ The following code sample shows how this could all be pieced together:
             <div class="cell @cell.Alias">
               @foreach (var field in cell.Fields)
               {
-                // render the form field with its partial view
+                // render the form field using its partial view
                 @Html.Partial(string.Format(@"FormEditor/FieldsSync/{0}", field.Type), field)
               }
             </div>

--- a/Docs/render.md
+++ b/Docs/render.md
@@ -16,7 +16,7 @@ By completing these three steps, you'll have your first form rendered in no time
 
 Have a look at the sample templates to see actual implementations of this.
 
-**Note:** If you have named your Form Editor property something else than "form" (see [Installing and setting up Form Editor](install.md)), you can specify the property name like this: ```ViewBag.FormName = "myForm";```
+**Note:** If you have named your Form Editor property something else than "form" (see [Installing and setting up Form Editor](install.md#setting-up-the-content-type)), you can specify the property name like this: ```ViewBag.FormName = "myForm";```
 
 ## Creating your own rendering
 If you want to create your own renderings, the sample templates and partial views should always be your starting point for inspiration. They are fairly well documented and will not be discussed in detail here. However, a few things are worth mentioning.

--- a/Docs/reuse.md
+++ b/Docs/reuse.md
@@ -12,42 +12,23 @@ First of all you need a form and some pages that will contain the form. Usually 
     - My Reusable Form
 ```
 
-Now add a content picker to the page content type and select *My Reusable Form* on the pages where you want to display the form. In the following paragraphs the content picker is assumed to have the alias ```formContentPicker```.
+Now add a content picker to the page content type and select *My Reusable Form* on the pages where you want to display the form. In the following, the content picker property is assumed to have the alias ```formContentPicker```.
 
 ## Tweaking the templates
-Once you've got the content all set up, you'll need to tweak the template a bit in order to:
+Once you've got the content all set up, you'll need to tell the Form Editor to use selected content (*My Reusable Form*) instead of the currently requested content. 
 
-1. Retrieve the form model from the selected form.
-2. Store the form submissions on the selected form.
-
-The "selected form" in this case is *My Reusable Form*.
-
-### For synchronous form postback
-Start out with the [sample template for synchronous form postback](../Source/Umbraco/Views/FormEditorSync.cshtml). If you replace the form model retrieval and form submission handling with the following lines, you're good to go:
+The sample templates for [synchronous](../Source/Umbraco/Views/FormEditorSync.cshtml) and [asynchronous](../Source/Umbraco/Views/FormEditorAsync.cshtml) form postback have already been prepared for this. All you need to do is assign the selected content to ```ViewBag.FormContent``` - the sample templates will do the rest.
 
 ```cs
 // get the selected content that contains the form model 
 var formContentId = Model.Content.GetPropertyValue<int>("formContentPicker");
 var formContent = Umbraco.TypedContent(formContentId);
 
-// get the form model (named "form" on the content type)
-var form = formContent.GetPropertyValue<FormModel>("form");
-
-// handle form submission in case of a postback
-// - the form submission will be stored on the content that contains the form model
-var formWasSubmitted = form.CollectSubmittedValues(formContent);
+// assign the selected content to ViewBag.FormContent
+ViewBag.FormContent = formContent;
 ```
 
-## For asynchronous form postback
-Start out with the [sample template for asynchronous form postback](../Source/Umbraco/Views/FormEditorAsync.cshtml) and replace the form retrieval with the following lines:
-
-```cs
-// get the selected content that contains the form model 
-var formContentId = Model.Content.GetPropertyValue<int>("formContentPicker");
-var formContent = Umbraco.TypedContent(formContentId);
-```
-
-That's it - you're done. 
+That's it - you're good to go. 
 
 ## Next step
 Onwards to [working with form submissions](submissions.md).

--- a/Grunt/package.json
+++ b/Grunt/package.json
@@ -17,6 +17,6 @@
         "grunt-template": "^0.2.3"
     },
     "meta": {
-        "version": "0.13.3.2"
+        "version": "0.14.0.1"
     }
 }

--- a/Grunt/package.json
+++ b/Grunt/package.json
@@ -17,6 +17,6 @@
         "grunt-template": "^0.2.3"
     },
     "meta": {
-        "version": "0.14.0.1"
+        "version": "0.14.0.2"
     }
 }

--- a/Source/Solution/FormEditor/FormModel.cs
+++ b/Source/Solution/FormEditor/FormModel.cs
@@ -590,7 +590,7 @@ namespace FormEditor
 		private List<MailAddress> ParseEmailAddresses(string emails)
 		{
 			var addresses = new List<MailAddress>();
-			foreach(var email in emails.Split(new[] { ',', ' ', ';' }))
+			foreach(var email in (emails ?? string.Empty).Split(new[] { ',', ' ', ';' }, StringSplitOptions.RemoveEmptyEntries))
 			{
 				try
 				{

--- a/Source/Solution/FormEditor/Properties/AssemblyInfo.cs
+++ b/Source/Solution/FormEditor/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("0.13.3.2")]
-[assembly: AssemblyFileVersion("0.13.3.2")]
+[assembly: AssemblyVersion("0.14.0.1")]
+[assembly: AssemblyFileVersion("0.14.0.1")]

--- a/Source/Solution/FormEditor/Properties/AssemblyInfo.cs
+++ b/Source/Solution/FormEditor/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("0.14.0.1")]
-[assembly: AssemblyFileVersion("0.14.0.1")]
+[assembly: AssemblyVersion("0.14.0.2")]
+[assembly: AssemblyFileVersion("0.14.0.2")]

--- a/Source/Umbraco/JS/FormEditor/FormEditorSync.js
+++ b/Source/Umbraco/JS/FormEditor/FormEditorSync.js
@@ -129,7 +129,10 @@
   }
 
   // form paging
-  $(".form-btn-next").click(function(e) {
+  $(".form-btn-next").click(function (e) {
+    if (validateActivePage() == false) {
+      return;
+    }
     if (activePage < _formTotalPages - 1) {
       activePage++;
       showActivePage();
@@ -141,6 +144,17 @@
       showActivePage();
     }
   });
+  function validateActivePage() {
+    var pageIsValid = true;
+    $("[name]", $($(".form-page")[activePage])).each(function (index, input) {
+      var isValid = validateField(input);
+      showHideValidationErrorForField(input, isValid);
+      if (isValid == false) {
+        pageIsValid = false;
+      }
+    });
+    return pageIsValid;
+  }
   function showActivePage() {
     $(".form-page").hide();
     $($(".form-page")[activePage]).show();

--- a/Source/Umbraco/Plugin/css/form.less
+++ b/Source/Umbraco/Plugin/css/form.less
@@ -391,6 +391,16 @@
       height: 20px;
       display: inline-block;
       vertical-align: top;
+
+      &.field-mandatory:after {
+        content: '*';
+        color: #b94a48;
+        position: relative;
+        left: 13px;
+        top: -3px;
+        font-size: 1.3em;
+        font-style: normal;
+      }
     }
 
     span.menu-label {

--- a/Source/Umbraco/Plugin/css/form.less
+++ b/Source/Umbraco/Plugin/css/form.less
@@ -7,12 +7,6 @@
 @sortablePlaceholderColor: #d0e7f1;
 @fontFamily: "Open Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
 
-/* 
-  this magic width should keep the field from breaking the view on a 768px screen
-  if the form label is disabled
-*/
-@fieldNameWidth: 140;
-
 .form-editor {
   width: 100%;
 
@@ -93,6 +87,10 @@
 
   table {
     width: 100%;
+    
+    &.form-cells{
+      table-layout: fixed;
+    }
 
     &.form-cells:hover tr td {
       border-color: @cellBorderColorActive;
@@ -127,23 +125,19 @@
         display: block;
         white-space: nowrap;
 
-        div.form-field-content {
-          display: inline-block;
+        span.form-field-content {
+          display: inline;
           cursor: pointer;
 
-          &.form-field-invalid {
-            span.form-field-icon-and-name:after {
-              font-family: "icomoon";
-              content: "\e25d";
-              color: @dangerColor;
-              font-size: 18px;
-              vertical-align: top;
-            }
+          &:hover span.form-field-name{
+            text-decoration: underline
+          }
 
+          &.form-field-invalid {
             span.form-field-name {
               /* take the width of the error icon into account */
-              width: (@fieldNameWidth - 20)*1px;
               color: @dangerColor;
+              font-weight: bold;
             }
           }
         }
@@ -155,14 +149,10 @@
 
         span.form-field-name {
           display: inline-block;
-          width: @fieldNameWidth*1px;
+          max-width: 75%;
           text-overflow: ellipsis;
           overflow: hidden;
           white-space: nowrap;
-
-          &:hover {
-            text-decoration: underline;
-          }
         }
       }
     }

--- a/Source/Umbraco/Plugin/editor/form.html
+++ b/Source/Umbraco/Plugin/editor/form.html
@@ -54,13 +54,13 @@
                     <td class="form-cell" ng-class="cell.alias" width="{{cellWidth(row, cell)}}%" ng-repeat="cell in row.cells">
                       <div ui-sortable="sortableOptionsField" ng-model="cell.fields" class="form-fields">
                         <div class="form-field" ng-repeat="field in cell.fields">
-                          <div class="form-field-content" ng-class="{'form-field-invalid': isInvalidField(field)}">
+                          <span class="form-field-content" ng-class="{'form-field-invalid': isInvalidField(field)}">
                             <span class="form-field-icon-and-name" ng-click="editField(field)">
                               <i class="field-icon" style="background-image: url('{{pathToFieldFile(field.icon)}}')"></i>
                               <span class="form-field-name">{{getFieldName(field)}}</span>
                             </span>
                             <i class="icon icon-delete dimmed" ng-click="removeField(field, cell)"></i>
-                          </div>
+                          </span>
                         </div>
                       </div>
                     </td>
@@ -123,11 +123,9 @@
                   <tbody>
                     <tr class="form-validation-rule" ng-repeat="rule in validation.rules">
                       <td class="form-validation-rule-field">
-                        <div class="form-field" ng-if="rule.field != null">
-                          <span ng-click="editRule(rule, validation)">
-                            <i class="field-icon" style="background-image: url('{{pathToFieldFile(rule.field.icon)}}')"></i>
-                            <span class="form-field-name">{{getFieldName(rule.field)}}</span>
-                          </span>
+                        <div class="form-field" ng-if="rule.field != null" ng-click="editRule(rule, validation)">
+                          <i class="field-icon" style="background-image: url('{{pathToFieldFile(rule.field.icon)}}')"></i>
+                          <span class="form-field-name">{{getFieldName(rule.field)}}</span>
                         </div>
                       </td>
                       <td class="form-validation-rule-condition">

--- a/Source/Umbraco/Plugin/editor/form.html
+++ b/Source/Umbraco/Plugin/editor/form.html
@@ -56,7 +56,7 @@
                         <div class="form-field" ng-repeat="field in cell.fields">
                           <span class="form-field-content" ng-class="{'form-field-invalid': isInvalidField(field)}">
                             <span class="form-field-icon-and-name" ng-click="editField(field)">
-                              <i class="field-icon" style="background-image: url('{{pathToFieldFile(field.icon)}}')"></i>
+                              <i class="field-icon" ng-class="{'field-mandatory': field.mandatory}" style="background-image: url('{{pathToFieldFile(field.icon)}}')"></i>
                               <span class="form-field-name">{{getFieldName(field)}}</span>
                             </span>
                             <i class="icon icon-delete dimmed" ng-click="removeField(field, cell)"></i>

--- a/Source/Umbraco/Views/FormEditorAsync.cshtml
+++ b/Source/Umbraco/Views/FormEditorAsync.cshtml
@@ -1,14 +1,12 @@
-﻿@using FormEditor;
-@using FormEditor.Rendering;
-@inherits Umbraco.Web.Mvc.UmbracoTemplatePage
+﻿@inherits Umbraco.Web.Mvc.UmbracoTemplatePage
 @{
   Layout = null;
 
-  // the content that contains the form model 
-  var formContent = Model.Content;
+  @* if the content being rendered does not containt the form property, pass the applicable content like this *@
+  // ViewBag.FormContent = myInstanceOfIPublishedContent;
 
-  // get the form model (named "form" on the content type)
-  var form = formContent.GetPropertyValue<FormModel>("form");  
+  @* if your form property is not called "form" on the content type, pass the property name like this *@
+  // ViewBag.FormName = "myForm";
 }
 <!DOCTYPE html>
 <html>
@@ -16,111 +14,16 @@
   <title>@Model.Content.Name</title>
   <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css" />
 </head>
-<body ng-app="formEditor">
-  @if(form.MaxSubmissionsExceeded() == false)
-  {
-    <form ng-controller="FormController" name="form" novalidate ng-cloak>
-      <div class="container" ng-show="showReceipt">
-        <h2>@form.ReceiptHeader</h2>
-        <p>
-          @Html.Raw(Umbraco.ReplaceLineBreaksForHtml(form.ReceiptBody ?? string.Empty))
-        </p>
-      </div>
+<body>
+  
+  @* render the form *@
+  @Html.Partial("FormEditor/Async");  
 
-      <div class="container" ng-hide="showReceipt">
-        @* NOTE: if you're not using form pages, you can access all form rows directly with form.Rows *@
-        @foreach(var page in form.Pages)
-        {
-          <div ng-show="isActivePage(@(form.Pages.IndexOf(page)))">
-            @foreach(var row in page.Rows)
-            {
-              <div class="row @row.Alias">
-                @foreach(var cell in row.Cells)
-                {
-                  <div class="cell @cell.Alias">
-                    @foreach(var field in cell.Fields)
-                    {
-                      // render the form field with a partial view
-                      // - the view is expected to be located at /Views/Partials/FormEditor/FieldsAsync/[field type].cshtml, e.g. /Views/Partials/FormEditor/FieldsAsync/core.checkbox.cshtml
-                      @Html.Partial(string.Format(@"FormEditor/FieldsAsync/{0}", field.Type), field)
-                    }
-                  </div>
-                }
-              </div>
-            }
-          </div>
-        }
-        @* paging links *@
-        <nav>
-          <ul class="pager">
-            <li class="previous" ng-hide="isFirstPage()">
-              <a href ng-click="goToPreviousPage()">
-                <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span> @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.previous"), "Previous")
-              </a>
-            </li>
-            <li class="next" ng-hide="isLastPage()">
-              <a href ng-click="goToNextPage()">
-                @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.next"), "Next") <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-              </a>
-            </li>
-          </ul>
-        </nav>
-        @* form validation errors container (for cross field validations) *@
-        <div class="form-group">
-          <div id="validationErrors" class="alert alert-danger hide" ng-class="{show: invalidValidations.length > 0}">
-            <h4>
-              <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-              @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.validationerrors.header"), "Form contains errors")
-            </h4>
-            <ul id="validationErrorsList">
-              <li ng-repeat="validation in invalidValidations">{{validation.errorMessage}}</li>
-            </ul>
-          </div>
-        </div>
-      </div>
+  @* include AngularJS *@
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.5/angular.min.js"></script>
 
-      @* add this if you want a live view of the form data *@
-      @*<hr/>
-        <pre>{{formData}}</pre>*@
-    </form>
+  @* include Form Editor script for asynchronous postback (using AngularJS) *@
+  <script src="/JS/FormEditor/FormEditorAsync.js" type="text/javascript"></script>
 
-    @* include AngularJS *@
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.5/angular.min.js"></script>
-
-    @* include Form Editor script for asynchronous postback (using AngularJS) *@
-    <script src="/JS/FormEditor/FormEditorAsync.js" type="text/javascript"></script>
-
-    @* this script section sets up state for the JS and thus needs to be a part of the template *@
-    <script type="text/javascript">
-      @* default values for form fields *@
-      var _formDefaultValues = {};
-      @foreach(var field in form.AllValueFields().Where(f => f.HasDefaultValue()))
-      {
-        @:_formDefaultValues.@field.FormSafeName = @field.DefaultValue();
-      }
-
-      @* form validations as an array of JSON objects *@
-      var _formValidations = @form.Validations.Render();
-
-      @* the Umbraco ID of the content to where the form should be submitted to *@
-      var _formId = @formContent.Id;
-
-      @* the total number of form pages *@
-      var _formTotalPages = @form.Pages.Count();
-
-      @* determine whether a receipt message is available *@
-      var _formHasReceipt = @(string.IsNullOrWhiteSpace(form.ReceiptHeader) ? "false" : "true");
-    </script>
-  }
-  else
-  {
-    @* max number of form submissions exceeded - show message *@
-    <div class="container">
-      <h2>@form.MaxSubmissionsExceededHeader</h2>
-      <p>
-        @Html.Raw(Umbraco.ReplaceLineBreaksForHtml(form.MaxSubmissionsExceededText ?? string.Empty))
-      </p>
-    </div>
-  }
 </body>
 </html>

--- a/Source/Umbraco/Views/FormEditorAsync.cshtml
+++ b/Source/Umbraco/Views/FormEditorAsync.cshtml
@@ -40,13 +40,13 @@
 </head>
 <body>
   
-  @* render the form *@
+  @* step 1: render the form with the Async partial *@
   @Html.Partial("FormEditor/Async", Umbraco.AssignedContentItem);  
 
-  @* include AngularJS *@
+  @* step 2: include AngularJS *@
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.5/angular.min.js"></script>
 
-  @* include Form Editor script for asynchronous postback (using AngularJS) *@
+  @* step 3: include Form Editor script for asynchronous postback (using AngularJS) *@
   <script src="/JS/FormEditor/FormEditorAsync.js" type="text/javascript"></script>
 
 </body>

--- a/Source/Umbraco/Views/FormEditorAsync.cshtml
+++ b/Source/Umbraco/Views/FormEditorAsync.cshtml
@@ -12,7 +12,31 @@
 <html>
 <head>
   <title>@Model.Content.Name</title>
-  <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css"/>
+  @* add some styles for Form Editor *@
+  <style>
+    /* required field indicator on the field labels */
+    div.form-group.required > label:after {
+      content: ' *';
+      color: #a94442;
+    }
+
+    /* pagination arrows */
+    ul.pager li.previous a:before, ul.pager li.next a:after {
+      content: "\e080";
+      position: relative;
+      top: 1px;
+      display: inline-block;
+      font-family: 'Glyphicons Halflings';
+      font-style: normal;
+      font-weight: 400;
+      line-height: 1;
+      -webkit-font-smoothing: antialiased;
+    }
+    ul.pager li.previous a:before {
+      content: "\e079";
+    }
+  </style>
 </head>
 <body>
   

--- a/Source/Umbraco/Views/FormEditorAsync.cshtml
+++ b/Source/Umbraco/Views/FormEditorAsync.cshtml
@@ -2,7 +2,7 @@
 @{
   Layout = null;
 
-  @* if the content being rendered does not containt the form property, pass the applicable content like this *@
+  @* if the content being rendered does not contain the form property, pass the applicable content like this *@
   // ViewBag.FormContent = myInstanceOfIPublishedContent;
 
   @* if your form property is not called "form" on the content type, pass the property name like this *@
@@ -17,7 +17,7 @@
 <body>
   
   @* render the form *@
-  @Html.Partial("FormEditor/Async");  
+  @Html.Partial("FormEditor/Async", Umbraco.AssignedContentItem);  
 
   @* include AngularJS *@
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.5/angular.min.js"></script>

--- a/Source/Umbraco/Views/FormEditorSync.cshtml
+++ b/Source/Umbraco/Views/FormEditorSync.cshtml
@@ -40,13 +40,13 @@
 </head>
 <body>
   
-  @* render the form *@
+  @* step 1: render the form with the Sync partial *@
   @Html.Partial("FormEditor/Sync", Umbraco.AssignedContentItem);
 
-  @* include jQuery *@
+  @* step 2: include jQuery *@
   <script src="https://code.jquery.com/jquery-2.1.4.min.js" type="text/javascript"></script>
 
-  @* include Form Editor script for synchronous postback (using jQuery) *@
+  @* step 3: include Form Editor script for synchronous postback (using jQuery) *@
   <script src="/JS/FormEditor/FormEditorSync.js" type="text/javascript"></script>
 
 </body>

--- a/Source/Umbraco/Views/FormEditorSync.cshtml
+++ b/Source/Umbraco/Views/FormEditorSync.cshtml
@@ -12,7 +12,31 @@
 <html>
 <head>
   <title>@Model.Content.Name</title>
-  <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css"/>
+  @* add some styles for Form Editor *@
+  <style>
+    /* required field indicator on the field labels */
+    div.form-group.required > label:after {
+      content: ' *';
+      color: #a94442;
+    }
+
+    /* pagination arrows */
+    ul.pager li.previous a:before, ul.pager li.next a:after {
+      content: "\e080";
+      position: relative;
+      top: 1px;
+      display: inline-block;
+      font-family: 'Glyphicons Halflings';
+      font-style: normal;
+      font-weight: 400;
+      line-height: 1;
+      -webkit-font-smoothing: antialiased;
+    }
+    ul.pager li.previous a:before {
+      content: "\e079";
+    }
+  </style>
 </head>
 <body>
   

--- a/Source/Umbraco/Views/FormEditorSync.cshtml
+++ b/Source/Umbraco/Views/FormEditorSync.cshtml
@@ -2,7 +2,7 @@
 @{
   Layout = null;
   
-  @* if the content being rendered does not containt the form property, pass the applicable content like this *@
+  @* if the content being rendered does not contain the form property, pass the applicable content like this *@
   // ViewBag.FormContent = myInstanceOfIPublishedContent;
 
   @* if your form property is not called "form" on the content type, pass the property name like this *@
@@ -17,7 +17,7 @@
 <body>
   
   @* render the form *@
-  @Html.Partial("FormEditor/Sync");
+  @Html.Partial("FormEditor/Sync", Umbraco.AssignedContentItem);
 
   @* include jQuery *@
   <script src="https://code.jquery.com/jquery-2.1.4.min.js" type="text/javascript"></script>

--- a/Source/Umbraco/Views/FormEditorSync.cshtml
+++ b/Source/Umbraco/Views/FormEditorSync.cshtml
@@ -1,21 +1,12 @@
-﻿@using FormEditor;
-@using FormEditor.Rendering
-@inherits Umbraco.Web.Mvc.UmbracoTemplatePage
+﻿@inherits Umbraco.Web.Mvc.UmbracoTemplatePage
 @{
   Layout = null;
-
-  // get the form model (named "form" on the content type)
-  var form = Model.Content.GetPropertyValue<FormModel>("form");
   
-  // handle form submission if this is a postback
-  // - this will also take care of redirecting to the success page (if configured)
-  var formWasSubmitted = form.CollectSubmittedValues();
+  @* if the content being rendered does not containt the form property, pass the applicable content like this *@
+  // ViewBag.FormContent = myInstanceOfIPublishedContent;
 
-  // show the receipt if the form was submitted and we have a receipt message
-  var showReceiptMessage = formWasSubmitted && string.IsNullOrWhiteSpace(form.ReceiptHeader) == false;
-
-  // show the max number of submissions exceeded message if applicable (and if the form was not submitted just now)
-  var showMaxSubmissionsExceededMessage = formWasSubmitted == false && form.MaxSubmissionsExceeded();
+  @* if your form property is not called "form" on the content type, pass the property name like this *@
+  // ViewBag.FormName = "myForm";
 }
 <!DOCTYPE html>
 <html>
@@ -24,103 +15,15 @@
   <link rel="stylesheet" href="http://getbootstrap.com/dist/css/bootstrap.min.css" />
 </head>
 <body>
-  @if(showReceiptMessage)
-  {
-    @* form was submitted and we have a receipt message - show message *@
-    <div class="container">
-      <h2>@form.ReceiptHeader</h2>
-      <p>
-        @Html.Raw(Umbraco.ReplaceLineBreaksForHtml(form.ReceiptBody ?? string.Empty))
-      </p>
-    </div>
-  }
-  else if(showMaxSubmissionsExceededMessage)
-  {
-    @* max number of form submissions exceeded - show message *@
-    <div class="container">
-      <h2>@form.MaxSubmissionsExceededHeader</h2>
-      <p>
-        @Html.Raw(Umbraco.ReplaceLineBreaksForHtml(form.MaxSubmissionsExceededText ?? string.Empty))
-      </p>
-    </div>
-  }
-  else
-  {
-    <form method="POST" enctype="multipart/form-data" novalidate>
-      <div class="container">
-        @* NOTE: if you're not using form pages, you can access all form rows directly with form.Rows *@
-        @foreach(var page in form.Pages)
-        {
-          <div class="form-page" style="@(page == form.Pages.First() ? null : "display:none;")">
-            @foreach(var row in page.Rows)
-            {
-              <div class="row @row.Alias">
-                @foreach(var cell in row.Cells)
-                {
-                  <div class="cell @cell.Alias">
-                    @foreach(var field in cell.Fields)
-                    {
-                      // render the form field with a partial view
-                      // - the view is expected to be located at /Views/Partials/FormEditor/FieldsSync/[field type].cshtml, e.g. /Views/Partials/FormEditor/FieldsSync/core.checkbox.cshtml
-                      @Html.Partial(string.Format(@"FormEditor/FieldsSync/{0}", field.Type), field)
-                    }
-                  </div>
-                }
-              </div>
-            }
-          </div>
-        }
-        @* paging links *@
-        <nav>
-          <ul class="pager">
-            <li class="previous form-btn-previous" style="display: none">
-              <a href="javascript:;">
-                <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span> @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.previous"), "Previous")
-              </a>
-            </li>
-            <li class="next form-btn-next" style="display: none">
-              <a href="javascript:;">
-                @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.next"), "Next") <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-              </a>
-            </li>
-          </ul>
-        </nav>
-        @* form validation errors container (for cross field validations) *@
-        <div class="row">
-          <div class="cell">
-            <div class="form-group">
-              <div id="validationErrors" class="alert alert-danger @(form.Validations.Any(v => v.Invalid) ? null : "hide")">
-                <h4>
-                  <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-                  @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.validationerrors.header"), "Form contains errors")
-                </h4>
-                <ul id="validationErrorsList">
-                  @foreach(var invalidValidation in form.Validations.Where(v => v.Invalid))
-                  {
-                    <li>@invalidValidation.ErrorMessage</li>
-                  }
-                </ul>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </form>
+  
+  @* render the form *@
+  @Html.Partial("FormEditor/Sync");
 
-    @* include jQuery *@
-    <script src="https://code.jquery.com/jquery-2.1.4.min.js" type="text/javascript"></script>
+  @* include jQuery *@
+  <script src="https://code.jquery.com/jquery-2.1.4.min.js" type="text/javascript"></script>
 
-    @* include Form Editor script for synchronous postback (using jQuery) *@
-    <script src="/JS/FormEditor/FormEditorSync.js" type="text/javascript"></script>
+  @* include Form Editor script for synchronous postback (using jQuery) *@
+  <script src="/JS/FormEditor/FormEditorSync.js" type="text/javascript"></script>
 
-    @* this script section sets up state for the JS and thus needs to be a part of the template *@
-    <script type="text/javascript">
-      @* render the form validations as an array of JSON objects *@
-      var _formValidations = @form.Validations.Render();
-
-      @* the total number of form pages *@
-      var _formTotalPages = @form.Pages.Count();
-    </script>
-  }
 </body>
 </html>

--- a/Source/Umbraco/Views/Partials/FormEditor/Async.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/Async.cshtml
@@ -72,7 +72,6 @@
           <div class="form-group">
             <div id="validationErrors" class="alert alert-danger hide" ng-class="{show: invalidValidations.length > 0}">
               <h4>
-                <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
                 @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.validationerrors.header"), "Form contains errors")
               </h4>
               <ul id="validationErrorsList">

--- a/Source/Umbraco/Views/Partials/FormEditor/Async.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/Async.cshtml
@@ -51,28 +51,34 @@
           </div>
         }
       </form>
-      @* paging links *@
+      @* 
+        paging links 
+        TIP: you can localize the "Previous" and "Next" texts by adding "form.paging.previous" and "form.paging.next" to the Umbraco dictionary
+      *@
       <nav>
         <ul class="pager">
           <li class="previous" ng-hide="isFirstPage()">
             <a href ng-click="goToPreviousPage()">
-              <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span> @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.previous"), "Previous")
+              @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.previous"), "Previous")
             </a>
           </li>
           <li class="next" ng-hide="isLastPage()">
             <a href ng-click="goToNextPage()">
-              @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.next"), "Next") <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+              @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.next"), "Next")
             </a>
           </li>
         </ul>
       </nav>
-      @* form validation errors container (for cross field validations) *@
+      @* 
+        form validation errors container (for cross field validations) 
+        TIP: you can localize the header text by adding "form.validationerrors.header" to the Umbraco dictionary
+      *@
       <div class="row form-validation-errors">
         <div class="cell">
           <div class="form-group">
             <div id="validationErrors" class="alert alert-danger hide" ng-class="{show: invalidValidations.length > 0}">
               <h4>
-                @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.validationerrors.header"), "Form contains errors")
+                @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.validationerrors.header"), "The form contains errors")
               </h4>
               <ul id="validationErrorsList">
                 <li ng-repeat="validation in invalidValidations">{{validation.errorMessage}}</li>

--- a/Source/Umbraco/Views/Partials/FormEditor/Async.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/Async.cshtml
@@ -1,0 +1,123 @@
+﻿@using FormEditor;
+@using FormEditor.Rendering;
+@inherits Umbraco.Web.Mvc.UmbracoViewPage
+@{
+  Layout = null;
+
+  // get the content that contains the form model (defaults to the current page)
+  var formContent = ViewBag.FormContent as IPublishedContent ?? Model;
+
+  // get the name of the form model property on the content type (defaults to "form")
+  var formPropertyName = ViewBag.FormName as string ?? "form";
+
+  // get the form model (named "form" on the content type)
+  var form = formContent.GetPropertyValue<FormModel>(formPropertyName);  
+}
+<div ng-app="formEditor">
+  @* only render the form if we can actually submit to it *@
+  @if(form.MaxSubmissionsExceeded() == false)
+  {
+    @* render the receipt message *@
+    <div class="container form-receipt" ng-cloak ng-show="showReceipt">
+      <h2>@form.ReceiptHeader</h2>
+      <p>
+        @Html.Raw(Umbraco.ReplaceLineBreaksForHtml(form.ReceiptBody ?? string.Empty))
+      </p>
+    </div>
+
+    @* render the form *@
+    <form ng-controller="FormController" name="form" novalidate ng-cloak ng-hide="showReceipt">
+      <div class="container form-data">
+        @* NOTE: if you're not using form pages, you can access all form rows directly with form.Rows *@
+        @foreach(var page in form.Pages)
+        {
+          <div class="form-page" ng-show="isActivePage(@(form.Pages.IndexOf(page)))">
+            @foreach(var row in page.Rows)
+            {
+              <div class="row @row.Alias">
+                @foreach(var cell in row.Cells)
+                {
+                  <div class="cell @cell.Alias">
+                    @foreach(var field in cell.Fields)
+                    {
+                      // render the form field with a partial view
+                      // - the view is expected to be located at /Views/Partials/FormEditor/FieldsAsync/[field type].cshtml, e.g. /Views/Partials/FormEditor/FieldsAsync/core.checkbox.cshtml
+                      @Html.Partial(string.Format(@"FormEditor/FieldsAsync/{0}", field.Type), field)
+                    }
+                  </div>
+                }
+              </div>
+            }
+          </div>
+        }
+        @* paging links *@
+        <nav>
+          <ul class="pager">
+            <li class="previous" ng-hide="isFirstPage()">
+              <a href ng-click="goToPreviousPage()">
+                <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span> @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.previous"), "Previous")
+              </a>
+            </li>
+            <li class="next" ng-hide="isLastPage()">
+              <a href ng-click="goToNextPage()">
+                @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.next"), "Next") <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+              </a>
+            </li>
+          </ul>
+        </nav>
+        @* form validation errors container (for cross field validations) *@
+        <div class="row form-validation-errors">
+          <div class="cell">
+            <div class="form-group">
+              <div id="validationErrors" class="alert alert-danger hide" ng-class="{show: invalidValidations.length > 0}">
+                <h4>
+                  <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+                  @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.validationerrors.header"), "Form contains errors")
+                </h4>
+                <ul id="validationErrorsList">
+                  <li ng-repeat="validation in invalidValidations">{{validation.errorMessage}}</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      @* add this if you want a live view of the form data *@
+      @*<hr/>
+        <pre>{{formData}}</pre>*@
+    </form>
+
+    @* this script section sets up state for the JS and thus needs to be a part of the template *@
+    <script type="text/javascript">
+      @* default values for form fields *@
+      var _formDefaultValues = {};
+      @foreach(var field in form.AllValueFields().Where(f => f.HasDefaultValue()))
+      {
+        @:_formDefaultValues.@field.FormSafeName = @field.DefaultValue();
+      }
+
+      @* form validations as an array of JSON objects *@
+      var _formValidations = @form.Validations.Render();
+
+      @* the Umbraco ID of the content to where the form should be submitted to *@
+      var _formId = @formContent.Id;
+
+      @* the total number of form pages *@
+      var _formTotalPages = @form.Pages.Count();
+
+      @* determine whether a receipt message is available *@
+      var _formHasReceipt = @(string.IsNullOrWhiteSpace(form.ReceiptHeader) ? "false" : "true");
+    </script>
+  }
+  else
+  {
+    @* max number of form submissions exceeded - show message *@
+    <div class="container form-max-submissions-exceeded">
+      <h2>@form.MaxSubmissionsExceededHeader</h2>
+      <p>
+        @Html.Raw(Umbraco.ReplaceLineBreaksForHtml(form.MaxSubmissionsExceededText ?? string.Empty))
+      </p>
+    </div>
+  }
+</div>

--- a/Source/Umbraco/Views/Partials/FormEditor/Async.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/Async.cshtml
@@ -13,12 +13,12 @@
   // get the form model (named "form" on the content type)
   var form = formContent.GetPropertyValue<FormModel>(formPropertyName);  
 }
-<div ng-app="formEditor">
+<div ng-app="formEditor" ng-controller="FormController" ng-cloak>
   @* only render the form if we can actually submit to it *@
   @if(form.MaxSubmissionsExceeded() == false)
   {
     @* render the receipt message *@
-    <div class="container form-receipt" ng-cloak ng-show="showReceipt">
+    <div class="container form-receipt" ng-show="showReceipt">
       <h2>@form.ReceiptHeader</h2>
       <p>
         @Html.Raw(Umbraco.ReplaceLineBreaksForHtml(form.ReceiptBody ?? string.Empty))
@@ -26,12 +26,12 @@
     </div>
 
     @* render the form *@
-    <form ng-controller="FormController" name="form" novalidate ng-cloak ng-hide="showReceipt">
-      <div class="container form-data">
-        @* NOTE: if you're not using form pages, you can access all form rows directly with form.Rows *@
+    <div class="container form-data" ng-hide="showReceipt">
+      <form name="form" novalidate>
         @foreach(var page in form.Pages)
         {
-          <div class="form-page" ng-show="isActivePage(@(form.Pages.IndexOf(page)))">
+          ViewBag.FormEditorPageNumber = form.Pages.IndexOf(page);
+          <div class="form-page" ng-show="isActivePage(@(ViewBag.FormEditorPageNumber))" ng-form="formPage@(ViewBag.FormEditorPageNumber)">
             @foreach(var row in page.Rows)
             {
               <div class="row @row.Alias">
@@ -50,43 +50,39 @@
             }
           </div>
         }
-        @* paging links *@
-        <nav>
-          <ul class="pager">
-            <li class="previous" ng-hide="isFirstPage()">
-              <a href ng-click="goToPreviousPage()">
-                <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span> @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.previous"), "Previous")
-              </a>
-            </li>
-            <li class="next" ng-hide="isLastPage()">
-              <a href ng-click="goToNextPage()">
-                @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.next"), "Next") <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-              </a>
-            </li>
-          </ul>
-        </nav>
-        @* form validation errors container (for cross field validations) *@
-        <div class="row form-validation-errors">
-          <div class="cell">
-            <div class="form-group">
-              <div id="validationErrors" class="alert alert-danger hide" ng-class="{show: invalidValidations.length > 0}">
-                <h4>
-                  <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-                  @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.validationerrors.header"), "Form contains errors")
-                </h4>
-                <ul id="validationErrorsList">
-                  <li ng-repeat="validation in invalidValidations">{{validation.errorMessage}}</li>
-                </ul>
-              </div>
+      </form>
+      @* paging links *@
+      <nav>
+        <ul class="pager">
+          <li class="previous" ng-hide="isFirstPage()">
+            <a href ng-click="goToPreviousPage()">
+              <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span> @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.previous"), "Previous")
+            </a>
+          </li>
+          <li class="next" ng-hide="isLastPage()">
+            <a href ng-click="goToNextPage()">
+              @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.next"), "Next") <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+            </a>
+          </li>
+        </ul>
+      </nav>
+      @* form validation errors container (for cross field validations) *@
+      <div class="row form-validation-errors">
+        <div class="cell">
+          <div class="form-group">
+            <div id="validationErrors" class="alert alert-danger hide" ng-class="{show: invalidValidations.length > 0}">
+              <h4>
+                <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+                @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.validationerrors.header"), "Form contains errors")
+              </h4>
+              <ul id="validationErrorsList">
+                <li ng-repeat="validation in invalidValidations">{{validation.errorMessage}}</li>
+              </ul>
             </div>
           </div>
         </div>
       </div>
-
-      @* add this if you want a live view of the form data *@
-      @*<hr/>
-        <pre>{{formData}}</pre>*@
-    </form>
+    </div>
 
     @* this script section sets up state for the JS and thus needs to be a part of the template *@
     <script type="text/javascript">

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.checkbox.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.checkbox.cshtml
@@ -1,11 +1,9 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.CheckboxField>
-<div class="form-group @(Model.Invalid? "has-error" : null)">
-  <div class="checkbox">
-    <label>
-      <input type="checkbox" name="@Model.FormSafeName" ng-model="formData.@Model.FormSafeName" value="true" @(Model.Mandatory ? "required" : null) />
-      @Model.Label
-    </label>
-  </div>
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid? "has-error" : null) checkbox">
+  <label>
+    <input type="checkbox" name="@Model.FormSafeName" ng-model="formData.@Model.FormSafeName" value="true" @(Model.Mandatory ? "required" : null) />
+    @Model.Label
+  </label>
 
   @Html.Partial("FormEditor/FieldsAsync/core.utils.helptext")
   @Html.Partial("FormEditor/FieldsAsync/core.utils.validationerror")

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.checkboxgroup.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.checkboxgroup.cshtml
@@ -5,7 +5,7 @@
   {
     <div class="checkbox">
       <label>
-        <input type="checkbox" ng-checked="hasMultiSelectValue('@Model.FormSafeName', '@HttpUtility.JavaScriptStringEncode(fieldValue.Value)')" ng-click="toggleMultiSelectValue('@Model.FormSafeName', '@fieldValue.Value', @Model.Mandatory.ToString().ToLowerInvariant())" />
+        <input type="checkbox" ng-checked="hasMultiSelectValue('@Model.FormSafeName', '@HttpUtility.JavaScriptStringEncode(fieldValue.Value)')" ng-click="toggleMultiSelectValue('@Model.FormSafeName', @ViewBag.FormEditorPageNumber, '@fieldValue.Value', @Model.Mandatory.ToString().ToLowerInvariant())" />
         @fieldValue.Value
       </label>
     </div>

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.checkboxgroup.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.checkboxgroup.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.CheckboxGroupField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)" name="@Model.FormSafeName" ng-model="@Model.FormSafeName">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)" name="@Model.FormSafeName" ng-model="@Model.FormSafeName">
   <label>@Model.Label</label>
   @foreach (var fieldValue in Model.FieldValues)
   {

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.date.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.date.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.DateField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <input type="date" class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" ng-model="formData.@Model.FormSafeName" @(Model.Mandatory ? "required" : null) />
 

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.dropdown.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.dropdown.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.DropdownField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <select class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" ng-model="formData.@Model.FormSafeName" @(Model.Mandatory ? "required" : null)>
     @if (string.IsNullOrEmpty(Model.DefaultText) == false)

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.email.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.email.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.EmailField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <input type="email" class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" placeholder="@Model.Placeholder" ng-model="formData.@Model.FormSafeName" multiple="@Model.Multiple" @(Model.Mandatory ? "required" : null) />
 

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.number.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.number.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.NumberField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <input type="number" class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" placeholder="@Model.Placeholder" ng-model="formData.@Model.FormSafeName" min="@Model.Min" max="@Model.Max" @(Model.Mandatory ? "required" : null) />
 

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.radiobuttongroup.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.radiobuttongroup.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.RadioButtonGroupField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label>@Model.Label</label>
   @foreach (var fieldValue in Model.FieldValues)
   {

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.selectbox.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.selectbox.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.SelectBoxField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <select class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" ng-model="formData.@Model.FormSafeName" @(Model.MultiSelect ? "multiple" : "") size="@(Model.Size ?? Model.FieldValues.Count())" @(Model.Mandatory ? "required" : null)>
     @* add non-visible default option - this keeps Angular from adding one *@

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.telephone.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.telephone.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.TelephoneField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <input type="tel" class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" placeholder="@Model.Placeholder" ng-model="formData.@Model.FormSafeName" @(Model.Mandatory ? "required" : null) />
 

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.textarea.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.textarea.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.TextAreaField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <textarea class="form-control" rows="4" id="@Model.FormSafeName" name="@Model.FormSafeName" placeholder="@Model.Placeholder" ng-model="formData.@Model.FormSafeName" maxlength="@(Model.MaxLength > 0 ? @Model.MaxLength.ToString() : null)" @(Model.Mandatory ? "required" : null)></textarea>
 

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.textbox.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.textbox.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.TextBoxField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <input type="text" class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" placeholder="@Model.Placeholder" ng-model="formData.@Model.FormSafeName" maxlength="@(Model.MaxLength > 0 ? @Model.MaxLength.ToString() : null)" @(Model.Mandatory ? "required" : null) />
 

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.upload.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.upload.cshtml
@@ -1,7 +1,7 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.UploadField>
 <div class="form-group @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
-  <input type="file" id="@Model.FormSafeName" name="@Model.FormSafeName" @(Model.Mandatory ? "required" : null) accept="@Model.GetValidExtensions()" file-upload />
+  <input type="file" id="@Model.FormSafeName" name="@Model.FormSafeName" @(Model.Mandatory ? "required-file" : null) accept="@Model.GetValidExtensions()" file-upload ng-model="formData.@Model.FormSafeName" />
 
   @Html.Partial("FormEditor/FieldsAsync/core.utils.helptext")
   @Html.Partial("FormEditor/FieldsAsync/core.utils.validationerror")

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.upload.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.upload.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.UploadField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <input type="file" id="@Model.FormSafeName" name="@Model.FormSafeName" @(Model.Mandatory ? "required-file" : null) accept="@Model.GetValidExtensions()" file-upload ng-model="formData.@Model.FormSafeName" />
 

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.url.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.url.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.UrlField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <input type="url" class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" placeholder="@Model.Placeholder" ng-model="formData.@Model.FormSafeName" @(Model.Mandatory ? "required" : null) http-prefix />
 

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.utils.validationerror.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.utils.validationerror.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.IFieldWithValidation>
-<div class="text-danger validation-error hide" ng-class="{show: form.$submitted && form.@(Model.FormSafeName).$invalid}">
+<div class="text-danger validation-error hide" ng-class="{show: shouldShowValidationError('@(Model.FormSafeName)', @(ViewBag.FormEditorPageNumber))}">
   <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
   @Model.ErrorMessage
 </div>

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.utils.validationerror.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.utils.validationerror.cshtml
@@ -1,6 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.IFieldWithValidation>
 <div class="text-danger validation-error hide" ng-class="{show: form.$submitted && form.@(Model.FormSafeName).$invalid}">
   <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-  <span class="sr-only">Error:</span>
   @Model.ErrorMessage
 </div>

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.utils.validationerror.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsAsync/core.utils.validationerror.cshtml
@@ -1,5 +1,4 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.IFieldWithValidation>
 <div class="text-danger validation-error hide" ng-class="{show: shouldShowValidationError('@(Model.FormSafeName)', @(ViewBag.FormEditorPageNumber))}">
-  <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
   @Model.ErrorMessage
 </div>

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.checkbox.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.checkbox.cshtml
@@ -1,11 +1,9 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.CheckboxField>
-<div class="form-group @(Model.Invalid? "has-error" : null)">
-  <div class="checkbox">
-    <label>
-      <input type="checkbox" name="@Model.FormSafeName" value="true" @(Model.Selected ? "checked" : null) @(Model.Mandatory ? "required" : null) />
-      @Model.Label
-    </label>
-  </div>
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid? "has-error" : null) checkbox">
+  <label>
+    <input type="checkbox" name="@Model.FormSafeName" value="true" @(Model.Selected ? "checked" : null) @(Model.Mandatory ? "required" : null)/>
+    @Model.Label
+  </label>
 
   @Html.Partial("FormEditor/FieldsSync/core.utils.helptext")
   @Html.Partial("FormEditor/FieldsSync/core.utils.validationerror")

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.checkboxgroup.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.checkboxgroup.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.CheckboxGroupField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label>@Model.Label</label>
   @foreach (var fieldValue in Model.FieldValues)
   {

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.date.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.date.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.DateField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <input type="date" class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" value="@Model.SubmittedValue" @(Model.Mandatory ? "required" : null) />
 

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.dropdown.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.dropdown.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.DropdownField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <select class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" @(Model.Mandatory ? "required" : null)>
     @if (string.IsNullOrEmpty(Model.DefaultText) == false)

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.email.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.email.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.EmailField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <input type="email" class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" placeholder="@Model.Placeholder" value="@Model.SubmittedValue" multiple="@Model.Multiple" @(Model.Mandatory ? "required" : null) />
 

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.number.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.number.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.NumberField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <input type="number" class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" placeholder="@Model.Placeholder" value="@Model.SubmittedValue" min="@Model.Min" max="@Model.Max" @(Model.Mandatory ? "required" : null) />
 

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.radiobuttongroup.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.radiobuttongroup.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.RadioButtonGroupField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label>@Model.Label</label>
   @foreach (var fieldValue in Model.FieldValues)
   {

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.selectbox.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.selectbox.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.SelectBoxField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <select class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" @(Model.MultiSelect ? "multiple" : "") size="@(Model.Size ?? Model.FieldValues.Count())" @(Model.Mandatory ? "required" : null)>
     @foreach (var fieldValue in Model.FieldValues)

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.telephone.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.telephone.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.TelephoneField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <input type="tel" class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" placeholder="@Model.Placeholder" value="@Model.SubmittedValue" @(Model.Mandatory ? "required" : null) />
 

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.textarea.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.textarea.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.TextAreaField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <textarea class="form-control" rows="4" id="@Model.FormSafeName" name="@Model.FormSafeName" placeholder="@Model.Placeholder" maxlength="@(Model.MaxLength > 0 ? @Model.MaxLength.ToString() : null)" @(Model.Mandatory ? "required" : null)>@Model.SubmittedValue</textarea>
 

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.textbox.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.textbox.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.TextBoxField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <input type="text" class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" placeholder="@Model.Placeholder" value="@Model.SubmittedValue" maxlength="@(Model.MaxLength > 0 ? @Model.MaxLength.ToString() : null)" @(Model.Mandatory ? "required" : null) />
 

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.upload.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.upload.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.UploadField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <input type="file" id="@Model.FormSafeName" name="@Model.FormSafeName" @(Model.Mandatory ? "required" : null) accept="@Model.GetValidExtensions()" />
 

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.url.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.url.cshtml
@@ -1,5 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.UrlField>
-<div class="form-group @(Model.Invalid ? "has-error" : null)">
+<div class="form-group @(Model.Mandatory ? "required" : null) @(Model.Invalid ? "has-error" : null)">
   <label for="@Model.FormSafeName">@Model.Label</label>
   <input type="url" class="form-control" id="@Model.FormSafeName" name="@Model.FormSafeName" placeholder="@Model.Placeholder" value="@Model.SubmittedValue" @(Model.Mandatory ? "required" : null) />
 

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.utils.validationerror.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.utils.validationerror.cshtml
@@ -1,5 +1,4 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.IFieldWithValidation>
 <div class="text-danger validation-error @(Model.Invalid ? null : "hide")">
-  <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
   @Model.ErrorMessage
 </div>

--- a/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.utils.validationerror.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/FieldsSync/core.utils.validationerror.cshtml
@@ -1,6 +1,5 @@
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<FormEditor.Fields.IFieldWithValidation>
 <div class="text-danger validation-error @(Model.Invalid ? null : "hide")">
   <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-  <span class="sr-only">Error:</span>
   @Model.ErrorMessage
 </div>

--- a/Source/Umbraco/Views/Partials/FormEditor/Sync.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/Sync.cshtml
@@ -47,7 +47,6 @@ else
   @* render the form *@
   <form method="POST" enctype="multipart/form-data" novalidate>
     <div class="container form-data">
-      @* NOTE: if you're not using form pages, you can access all form rows directly with form.Rows *@
       @foreach(var page in form.Pages)
       {
         <div class="form-page" style="@(page == form.Pages.First() ? null : "display:none;")">

--- a/Source/Umbraco/Views/Partials/FormEditor/Sync.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/Sync.cshtml
@@ -92,7 +92,6 @@ else
           <div class="form-group">
             <div id="validationErrors" class="alert alert-danger @(form.Validations.Any(v => v.Invalid) ? null : "hide")">
               <h4>
-                <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
                 @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.validationerrors.header"), "Form contains errors")
               </h4>
               <ul id="validationErrorsList">

--- a/Source/Umbraco/Views/Partials/FormEditor/Sync.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/Sync.cshtml
@@ -68,31 +68,37 @@ else
           }
         </div>
       }
-      @* paging links *@
+      @* 
+        paging links 
+        TIP: you can localize the "Previous" and "Next" texts by adding "form.paging.previous" and "form.paging.next" to the Umbraco dictionary
+      *@
       @if(form.Pages.Count() > 1)
       {
         <nav>
           <ul class="pager">
             <li class="previous form-btn-previous" style="display: none">
               <a href="javascript:;">
-                <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span> @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.previous"), "Previous")
+                @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.previous"), "Previous")
               </a>
             </li>
             <li class="next form-btn-next" style="display: none">
               <a href="javascript:;">
-                @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.next"), "Next") <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+                @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.next"), "Next")
               </a>
             </li>
           </ul>
         </nav>
       }
-      @* form validation errors container (for cross field validations) *@
+      @*
+        form validation errors container (for cross field validations)
+        TIP: you can localize the header text by adding "form.validationerrors.header" to the Umbraco dictionary
+      *@
       <div class="row form-validation-errors">
         <div class="cell">
           <div class="form-group">
             <div id="validationErrors" class="alert alert-danger @(form.Validations.Any(v => v.Invalid) ? null : "hide")">
               <h4>
-                @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.validationerrors.header"), "Form contains errors")
+                @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.validationerrors.header"), "The form contains errors")
               </h4>
               <ul id="validationErrorsList">
                 @foreach(var invalidValidation in form.Validations.Where(v => v.Invalid))

--- a/Source/Umbraco/Views/Partials/FormEditor/Sync.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/Sync.cshtml
@@ -1,0 +1,120 @@
+﻿@using FormEditor;
+@using FormEditor.Rendering
+@inherits Umbraco.Web.Mvc.UmbracoViewPage
+@{
+  // get the content that contains the form model (defaults to the current page)
+  var formContent = ViewBag.FormContent as IPublishedContent ?? Model;
+  
+  // get the name of the form model property on the content type (defaults to "form")
+  var formPropertyName = ViewBag.FormName as string ?? "form";
+  
+  // get the form model
+  var form = formContent.GetPropertyValue<FormModel>(formPropertyName);
+  
+  // handle form submission if this is a postback
+  // - this will also take care of redirecting to the success page (if configured)
+  var formWasSubmitted = form.CollectSubmittedValues();
+
+  // show the receipt if the form was submitted and we have a receipt message
+  var showReceiptMessage = formWasSubmitted && string.IsNullOrWhiteSpace(form.ReceiptHeader) == false;
+
+  // show the max number of submissions exceeded message if applicable (and if the form was not submitted just now)
+  var showMaxSubmissionsExceededMessage = formWasSubmitted == false && form.MaxSubmissionsExceeded();
+}
+
+@if(showReceiptMessage)
+{
+  @* form was submitted and we have a receipt message - show message *@
+  <div class="container form-receipt">
+    <h2>@form.ReceiptHeader</h2>
+    <p>
+      @Html.Raw(Umbraco.ReplaceLineBreaksForHtml(form.ReceiptBody ?? string.Empty))
+    </p>
+  </div>
+}
+else if(showMaxSubmissionsExceededMessage)
+{
+  @* max number of form submissions exceeded - show message *@
+  <div class="container form-max-submissions-exceeded">
+    <h2>@form.MaxSubmissionsExceededHeader</h2>
+    <p>
+      @Html.Raw(Umbraco.ReplaceLineBreaksForHtml(form.MaxSubmissionsExceededText ?? string.Empty))
+    </p>
+  </div>
+}
+else
+{
+  @* render the form *@
+  <form method="POST" enctype="multipart/form-data" novalidate>
+    <div class="container form-data">
+      @* NOTE: if you're not using form pages, you can access all form rows directly with form.Rows *@
+      @foreach(var page in form.Pages)
+      {
+        <div class="form-page" style="@(page == form.Pages.First() ? null : "display:none;")">
+          @foreach(var row in page.Rows)
+          {
+            <div class="row @row.Alias">
+              @foreach(var cell in row.Cells)
+              {
+                <div class="cell @cell.Alias">
+                  @foreach(var field in cell.Fields)
+                  {
+                    // render the form field with a partial view
+                    // - the view is expected to be located at /Views/Partials/FormEditor/FieldsSync/[field type].cshtml, e.g. /Views/Partials/FormEditor/FieldsSync/core.checkbox.cshtml
+                    @Html.Partial(string.Format(@"FormEditor/FieldsSync/{0}", field.Type), field)
+                  }
+                </div>
+              }
+            </div>
+          }
+        </div>
+      }
+      @* paging links *@
+      @if(form.Pages.Count() > 1)
+      {
+        <nav>
+          <ul class="pager">
+            <li class="previous form-btn-previous" style="display: none">
+              <a href="javascript:;">
+                <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span> @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.previous"), "Previous")
+              </a>
+            </li>
+            <li class="next form-btn-next" style="display: none">
+              <a href="javascript:;">
+                @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.paging.next"), "Next") <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+              </a>
+            </li>
+          </ul>
+        </nav>
+      }
+      @* form validation errors container (for cross field validations) *@
+      <div class="row form-validation-errors">
+        <div class="cell">
+          <div class="form-group">
+            <div id="validationErrors" class="alert alert-danger @(form.Validations.Any(v => v.Invalid) ? null : "hide")">
+              <h4>
+                <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+                @Umbraco.Coalesce(Umbraco.GetDictionaryValue("form.validationerrors.header"), "Form contains errors")
+              </h4>
+              <ul id="validationErrorsList">
+                @foreach(var invalidValidation in form.Validations.Where(v => v.Invalid))
+                {
+                  <li>@invalidValidation.ErrorMessage</li>
+                }
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
+    
+  @* this script section sets up state for the JS and thus needs to be a part of the template *@
+  <script type="text/javascript">
+    @* render the form validations as an array of JSON objects *@
+    var _formValidations = @form.Validations.Render();
+
+    @* the total number of form pages *@
+    var _formTotalPages = @form.Pages.Count();
+  </script>
+}

--- a/Source/Umbraco/Views/Partials/FormEditor/Sync.cshtml
+++ b/Source/Umbraco/Views/Partials/FormEditor/Sync.cshtml
@@ -13,7 +13,7 @@
   
   // handle form submission if this is a postback
   // - this will also take care of redirecting to the success page (if configured)
-  var formWasSubmitted = form.CollectSubmittedValues();
+  var formWasSubmitted = form.CollectSubmittedValues(formContent);
 
   // show the receipt if the form was submitted and we have a receipt message
   var showReceiptMessage = formWasSubmitted && string.IsNullOrWhiteSpace(form.ReceiptHeader) == false;


### PR DESCRIPTION
- Split rendering into partial views for easier reuse.
- Removed glyphicons and other bootstrap markup from partials.
- Added required indicators both backend and frontend
- Greatly improved client side validation for multi page forms.
- Allowed fields to take up more space backend.
- Updated docs.