### PR TITLE
missing condition "core.fieldvalueisnot" fix

### DIFF
--- a/Source/Umbraco/JS/FormEditor/FormEditorAsync.js
+++ b/Source/Umbraco/JS/FormEditor/FormEditorAsync.js
@@ -278,7 +278,7 @@ addFormEditorCondition("core.fieldvalueisnot", function (rule, fieldValue, formD
   return (fieldValue || "").toLowerCase() != (rule.condition.expectedFieldValue || "").toLowerCase();
 });
 // - "field value is" condition (negation of "field value is not" condition):
-addFormEditorCondition("", function (rule, fieldValue, formData) {
+addFormEditorCondition("core.fieldvalueis", function (rule, fieldValue, formData) {
   return !(getFormEditorCondition("core.fieldvalueisnot")(rule, fieldValue, formData));
 });
 // - "field value does not other field value" condition:


### PR DESCRIPTION
For some reason the "core.fieldvalueisnot" was left blank