### PR TITLE
Update SQL Storage example to use nvarchar(4000) instead of default nvarchar(255)

### DIFF
--- a/Samples/SQL storage index/ApplicationEvents.cs
+++ b/Samples/SQL storage index/ApplicationEvents.cs
@@ -15,7 +15,9 @@ namespace FormEditor.SqlIndex
 			if (db.TableExist("FormEditorEntries") == false)
 			{
 				db.CreateTable<Entry>(false);
-			}
+                //Hack to get SQL server to use NVARCHAR(MAX) datatype
+                dbContext.Database.Execute("ALTER TABLE FormEditorEntries ALTER COLUMN FieldValues NVARCHAR(MAX)");
+            }
 			if (db.TableExist("FormEditorFiles") == false)
 			{
 				db.CreateTable<File>(false);

--- a/Samples/SQL storage index/Storage/Entry.cs
+++ b/Samples/SQL storage index/Storage/Entry.cs
@@ -13,7 +13,8 @@ namespace FormEditor.SqlIndex.Storage
 		public int Id { get; set; }
 		public Guid EntryId { get; set; }
 		public int ContentId { get; set; }
-		public string FieldValues { get; set; }
+        [Length(4000)]
+        public string FieldValues { get; set; }
 		public DateTime CreatedDate { get; set; }
 	}
 }


### PR DESCRIPTION
In implementing the sample SQL storage on SQL Server I found that without decoration SQL server automatically created the Field values string field as a nvarchar(255) field, this was no where long enough to keep even a few Field values so I added a decoration [Length(4000)] to make it nvarchar(4000), 
I also added an optional hack during creation to update the field to nvarchar(max), although this will only work for SQL server not other SQL based databases.