### PR TITLE
Allow multiple notificatio recipients (fix #73)

### DIFF
--- a/Source/Umbraco/Plugin/editor/form.html
+++ b/Source/Umbraco/Plugin/editor/form.html
@@ -214,7 +214,7 @@
         Recipient addresses
       </label>
       <div class="controls controls-row">
-        <input type="email" multiple="true" class="umb-editor" id="emailNotificationRecipients" ng-model="model.value.emailNotificationRecipients" />
+        <input type="text" form-editor-multiple-emails class="umb-editor" id="emailNotificationRecipients" ng-model="model.value.emailNotificationRecipients" />
       </div>
       <label class="control-label" for="emailNotificationSubject" form-editor-localize key="emailNotification.subject">
         Email subject

--- a/Source/Umbraco/Plugin/js/directives/multipleEmails.js
+++ b/Source/Umbraco/Plugin/js/directives/multipleEmails.js
@@ -1,0 +1,29 @@
+﻿angular.module("umbraco.directives").directive("formEditorMultipleEmails", [
+  function () {
+    var EMAIL_REGEXP = /^[_a-z0-9]+(\.[_a-z0-9]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,10})$/;
+    return {
+      require: "ngModel",
+      restrict: "A",
+      link: function (scope, element, attrs, ctrl) {
+        ctrl.$parsers.unshift(function (viewValue) {
+          if (!viewValue) {
+            ctrl.$setValidity("formEditorMultipleEmails", true);
+            return viewValue;
+          }
+
+          var valid = _.every(viewValue.split(','), function (email) {
+            return EMAIL_REGEXP.test(email.trim());
+          });
+
+          if (valid) {
+            ctrl.$setValidity("formEditorMultipleEmails", true);
+            return viewValue;
+          } else {
+            ctrl.$setValidity("formEditorMultipleEmails", false);
+            return undefined;
+          }
+        });
+      }
+    };
+  }
+]);

--- a/Source/Umbraco/Plugin/js/directives/multipleEmails.js
+++ b/Source/Umbraco/Plugin/js/directives/multipleEmails.js
@@ -1,6 +1,6 @@
 ﻿angular.module("umbraco.directives").directive("formEditorMultipleEmails", [
   function () {
-    var EMAIL_REGEXP = /^[_a-z0-9]+(\.[_a-z0-9]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,10})$/;
+    var EMAIL_REGEXP = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     return {
       require: "ngModel",
       restrict: "A",


### PR DESCRIPTION
Created a custom directive for the Umbraco backend that lets a text field accept multiple (or no) email addresses.